### PR TITLE
Bevy 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - Unreleased
 
+### Added
+- Added ability to have multiple shards in `DiscordBotConfig`
+
 ### Changed
 - Upgraded bevy dependency from `0.13` to `0.15`
 - Made macros accessible to crate only - [PR #6](https://github.com/AS1100K/bevy-discord/pulls/6)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Upgraded bevy dependency from `0.13` to `0.15`
-- Made macros accessible to crate only - [PR #6](https://github.com/AS1100K/bevy-discord/pulls/6)
+- Made macros accessible to crate only - [60df93](https://github.com/AS1100K/bevy-discord/commit/60df9357c661a8bdc2caba39ce925f0e20b81b81)
 
 ### Removed
 - Unused macros

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - Unreleased
+
+## Changed
+- Upgraded bevy dependency from `0.13` to `0.15`
+
 ## [0.4.0] - 2024-11-08
 
 ## Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.5.0] - Unreleased
+## [0.5.0] - 2024-11-30
 
 ### Added
 - Added ability to have multiple shards in `DiscordBotConfig`
 
 ### Changed
-- Upgraded bevy dependency from `0.13` to `0.15`
+- Upgraded bevy dependency from `0.14` to `0.15`
 - Made macros accessible to crate only - [60df93](https://github.com/AS1100K/bevy-discord/commit/60df9357c661a8bdc2caba39ce925f0e20b81b81)
 
 ### Removed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,15 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.5.0] - Unreleased
 
-## Changed
+### Changed
 - Upgraded bevy dependency from `0.13` to `0.15`
+- Made macros accessible to crate only - [PR #6](https://github.com/AS1100K/bevy-discord/pulls/6)
+
+### Removed
+- Unused macros
 
 ## [0.4.0] - 2024-11-08
 
-## Removed
+### Removed
 - `webhook` module and feature
 
-## Changed
+### Changed
 - Add `DiscordHttpResource` once `BReadyEvent` is emitted in `DiscordBotPlugin`
 - Upgraded bevy dependency from `0.13` to `0.14`
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy-discord"
 description = "A bevy plugin for sending and receiving discord messages."
-version = "0.4.0"
+version = "0.5.0"
 edition = "2021"
 authors = ["Aditya Kumar <theadityakumardeveloper@gmail.com>"]
 readme = "README.md"
@@ -17,8 +17,8 @@ http = ["dep:serenity"]
 bot_cache = ["serenity/cache"]
 
 [dependencies]
-bevy_app = "0.14"
-bevy_ecs = "0.14"
+bevy_app = "0.15.0-rc.3"
+bevy_ecs = "0.15.0-rc.3"
 flume = "0.11"
 serenity = { version = "0.12", features = [
     "gateway",
@@ -30,7 +30,7 @@ tracing = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "rt"] }
 
 [dev-dependencies]
-bevy = "0.14"
+bevy = "0.15.0-rc.3"
 serde_json = "1"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,8 +17,8 @@ http = ["dep:serenity"]
 bot_cache = ["serenity/cache"]
 
 [dependencies]
-bevy_app = "0.15.0-rc.3"
-bevy_ecs = "0.15.0-rc.3"
+bevy_app = "0.15"
+bevy_ecs = "0.15"
 flume = "0.11"
 serenity = { version = "0.12", features = [
     "gateway",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy-discord"
 description = "A bevy plugin for sending and receiving discord messages."
-version = "0.5.0"
+version = "0.5.0-beta.1"
 edition = "2021"
 authors = ["Aditya Kumar <theadityakumardeveloper@gmail.com>"]
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "bevy-discord"
 description = "A bevy plugin for sending and receiving discord messages."
-version = "0.5.0-beta.1"
+version = "0.5.0"
 edition = "2021"
 authors = ["Aditya Kumar <theadityakumardeveloper@gmail.com>"]
 readme = "README.md"

--- a/PRERELEASE-CHANGELOG.md
+++ b/PRERELEASE-CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ability to have multiple shards in `DiscordBotConfig`
 
 ### Changed
-- Upgraded bevy dependency from `0.13` to `0.15.0-rc.3`
+- Upgraded bevy dependency from `0.14` to `0.15.0-rc.3`
 - Made macros accessible to crate only - [60df93](https://github.com/AS1100K/bevy-discord/commit/60df9357c661a8bdc2caba39ce925f0e20b81b81)
 
 ### Removed

--- a/PRERELEASE-CHANGELOG.md
+++ b/PRERELEASE-CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.5.0-beta.1]
+
+### Added
+- Added ability to have multiple shards in `DiscordBotConfig`
+
+### Changed
+- Upgraded bevy dependency from `0.13` to `0.15.0-rc.3`
+- Made macros accessible to crate only - [60df93](https://github.com/AS1100K/bevy-discord/commit/60df9357c661a8bdc2caba39ce925f0e20b81b81)
+
+### Removed
+- Unused macros

--- a/README.md
+++ b/README.md
@@ -1,14 +1,10 @@
 # Bevy Discord Plugin
 
 ![GitHub License](https://img.shields.io/github/license/AS1100K/bevy-discord)
-![Crates.io Version](https://img.shields.io/crates/v/bevy-discord)
+[![Crates.io Version](https://img.shields.io/crates/v/bevy-discord)](https://crates.io/crates/bevy-discord)
 ![CI](https://github.com/as1100k/bevy-discord/actions/workflows/ci.yml/badge.svg?event=push)
 
 A very simple, bevy plugin that let you send and receive messages through bevy events.
-
-> !NOTE
-> This branch `bevy-0.15` is based on top of `0.15` release candidates of bevy. This branch might introduce major changes
-> and might even take some time to get merged after release of bevy `0.15.0`.
 
 ## Installation
 
@@ -117,9 +113,9 @@ Currently, the following Discord/Serenity features are not supported:
 This crate aims to track bevy's versions. It also follows the semver standard. Below is a chart which versions of this
 crate are compatible with which bevy version:
 
-| Version                                                                                 | Bevy Version |
-|-----------------------------------------------------------------------------------------|--------------|
-| `0.2.x`                                                                                 | `0.13.x`     |
-| `0.3.x`                                                                                 | `0.13.x`     |
-| `0.4.x`                                                                                 | `0.14.x`     |
-| `0.5.x` [On Branch `bevy-0.15`](https://github.com/AS1100K/bevy-discord/tree/bevy-0.15) | `0.15.x`     |
+| Version | Bevy Version |
+|---------|--------------|
+| `0.2.x` | `0.13.x`     |
+| `0.3.x` | `0.13.x`     |
+| `0.4.x` | `0.14.x`     |
+| `0.5.x` | `0.15.x`     |

--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 
 A very simple, bevy plugin that let you send and receive messages through bevy events.
 
+> !NOTE
+> This branch `bevy-0.15` is based on top of `0.15` release candidates of bevy. This branch might introduce major changes
+> and might even take some time to get merged after release of bevy `0.15.0`.
+
 ## Installation
 
 Add `bevy-discord` as your dependency:

--- a/examples/slash_commands.rs
+++ b/examples/slash_commands.rs
@@ -2,7 +2,7 @@
 use bevy::prelude::*;
 use bevy_discord::bot::{events::*, DiscordBotConfig, DiscordBotPlugin};
 use bevy_discord::runtime::tokio_runtime;
-use bevy_discord::serenity::all::*;
+use bevy_discord::serenity::all::{Command, CreateCommand, GatewayIntents, CreateInteractionResponse, CreateInteractionResponseMessage};
 use bevy_discord::serenity::model::application::Interaction;
 
 fn main() {

--- a/examples/slash_commands.rs
+++ b/examples/slash_commands.rs
@@ -2,7 +2,10 @@
 use bevy::prelude::*;
 use bevy_discord::bot::{events::*, DiscordBotConfig, DiscordBotPlugin};
 use bevy_discord::runtime::tokio_runtime;
-use bevy_discord::serenity::all::{Command, CreateCommand, GatewayIntents, CreateInteractionResponse, CreateInteractionResponseMessage};
+use bevy_discord::serenity::all::{
+    Command, CreateCommand, CreateInteractionResponse, CreateInteractionResponseMessage,
+    GatewayIntents,
+};
 use bevy_discord::serenity::model::application::Interaction;
 
 fn main() {

--- a/src/bot/common.rs
+++ b/src/bot/common.rs
@@ -1,5 +1,5 @@
 use super::events::*;
-use crate::create_event_collection_and_handler;
+use crate::common::create_event_collection_and_handler;
 use bevy_ecs::prelude::*;
 
 create_event_collection_and_handler!(

--- a/src/bot/handle.rs
+++ b/src/bot/handle.rs
@@ -4,7 +4,7 @@ use flume::Sender;
 use serenity::all::*;
 use tracing::error;
 
-use crate::send_event;
+use crate::common::send_event;
 
 use super::{common::BEventCollection, events::*};
 

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -41,8 +41,9 @@ use event_handlers::*;
 use events::*;
 
 use crate::bot::handle::Handle;
+use crate::common::{initialize_field_with_doc, override_field_with_doc};
 use crate::runtime::tokio_runtime;
-use crate::{initialize_field_with_doc, override_field_with_doc, DiscordSet};
+use crate::DiscordSet;
 
 mod common;
 mod event_handlers;

--- a/src/bot/mod.rs
+++ b/src/bot/mod.rs
@@ -246,19 +246,21 @@ fn setup_bot(mut commands: Commands, discord_bot_config: Res<DiscordBotConfig>) 
         client_builder = client_builder.activity(activity);
     }
 
+    let discord_bot_config_clone = discord_bot_config.clone();
+
     tokio_runtime().spawn(async move {
         let mut client = client_builder
             .await
             .expect("Unable to build discord Client");
 
-        if discord_bot_config.shards == 0 {
+        if discord_bot_config_clone.shards == 0 {
             client
                 .start()
                 .await
                 .expect("Unable to run the discord Client");
         } else {
             client
-                .start_shards(discord_bot_config.shards)
+                .start_shards(discord_bot_config_clone.shards)
                 .await
                 .expect("Unable to run the discord Client with multiple shards.")
         }

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,42 +1,9 @@
-/// wrapper around `Self::default()`
-macro_rules! new {
-    () => {
-        #[must_use]
-        #[doc = "Creates a new empty struct."]
-        pub fn new() -> Self {
-            Self::default()
-        }
-    };
-}
-
-/// Creates a function that override the field which is `Option`
-macro_rules! override_field {
-    ($name:ident, $type:ty) => {
-        #[doc = concat!("Adds `", stringify!($name), "` field.")]
-        pub fn $name(mut self, $name: $type) -> Self {
-            self.$name = Some($name);
-            self
-        }
-    };
-}
-
 /// Creates a function that override the field which is `Option` and documentation
 macro_rules! override_field_with_doc {
     ($name:ident, $type:ty, $doc:expr) => {
         #[doc = $doc]
         pub fn $name(mut self, $name: $type) -> Self {
             self.$name = Some($name);
-            self
-        }
-    };
-}
-
-/// Creates a function that override/initialize a field
-macro_rules! initialize_field {
-    ($name:ident, $type:ty) => {
-        #[doc = concat!("Adds `", stringify!($name), "` field.")]
-        pub fn $name(mut self, $name: $type) -> Self {
-            self.$name = $name;
             self
         }
     };
@@ -102,6 +69,6 @@ macro_rules! send_event {
 }
 
 pub(crate) use {
-    create_event_collection_and_handler, initialize_field, initialize_field_with_doc, new,
-    override_field, override_field_with_doc, send_event,
+    create_event_collection_and_handler, initialize_field_with_doc, override_field_with_doc,
+    send_event,
 };

--- a/src/common.rs
+++ b/src/common.rs
@@ -1,5 +1,4 @@
 /// wrapper around `Self::default()`
-#[macro_export]
 macro_rules! new {
     () => {
         #[must_use]
@@ -11,7 +10,6 @@ macro_rules! new {
 }
 
 /// Creates a function that override the field which is `Option`
-#[macro_export]
 macro_rules! override_field {
     ($name:ident, $type:ty) => {
         #[doc = concat!("Adds `", stringify!($name), "` field.")]
@@ -23,7 +21,6 @@ macro_rules! override_field {
 }
 
 /// Creates a function that override the field which is `Option` and documentation
-#[macro_export]
 macro_rules! override_field_with_doc {
     ($name:ident, $type:ty, $doc:expr) => {
         #[doc = $doc]
@@ -35,7 +32,6 @@ macro_rules! override_field_with_doc {
 }
 
 /// Creates a function that override/initialize a field
-#[macro_export]
 macro_rules! initialize_field {
     ($name:ident, $type:ty) => {
         #[doc = concat!("Adds `", stringify!($name), "` field.")]
@@ -47,7 +43,6 @@ macro_rules! initialize_field {
 }
 
 /// Creates a function that override/initialize a field with custom documentation
-#[macro_export]
 macro_rules! initialize_field_with_doc {
     ($name:ident, $type:ty, $doc:expr) => {
         #[doc = $doc]
@@ -58,7 +53,6 @@ macro_rules! initialize_field_with_doc {
     };
 }
 
-#[macro_export]
 macro_rules! create_event_collection_and_handler {
     (
         $(
@@ -95,7 +89,6 @@ macro_rules! create_event_collection_and_handler {
     };
 }
 
-#[macro_export]
 macro_rules! send_event {
     ($self:ident, $event:ident { $($field:ident),* }) => {
         if let Err(_) = $self.tx.send_async(
@@ -107,3 +100,8 @@ macro_rules! send_event {
         }
     };
 }
+
+pub(crate) use {
+    create_event_collection_and_handler, initialize_field, initialize_field_with_doc, new,
+    override_field, override_field_with_doc, send_event,
+};


### PR DESCRIPTION
### Added
- Added ability to have multiple shards in `DiscordBotConfig`

### Changed
- Upgraded bevy dependency from `0.14` to `0.15`
- Made macros accessible to crate only 
  _This is done because these macros were created to be used internally by the crate, and it's use outside the crate isn't suitable as these macros were specifically designed for this crate only._

### Removed
- Unused macros