### PR TITLE
Update send_events system to not use `World` directly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,7 @@ tracing = "0.1"
 tokio = { version = "1", features = ["rt-multi-thread", "rt"] }
 discord-sdk = { version = "0.4", optional = true }
 async-trait = { version = "0.1", optional = true }
+pastey = "0.1"
 
 [dev-dependencies]
 bevy = "0.15"

--- a/src/bot/handle.rs
+++ b/src/bot/handle.rs
@@ -6,54 +6,74 @@ use tracing::error;
 
 use crate::common::send_event;
 
-use crate::events::{bot::*, EventCollection};
+use crate::events::{bot::*, EventCollectionBot};
 
 pub(super) struct Handle {
-    pub tx: Sender<EventCollection>,
+    pub tx: Sender<EventCollectionBot>,
 }
 
 #[async_trait]
 impl EventHandler for Handle {
     async fn command_permissions_update(&self, ctx: Context, permission: CommandPermissions) {
-        send_event!(self, BCommandPermissionsUpdate { ctx, permission });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BCommandPermissionsUpdate { ctx, permission }
+        );
     }
 
     async fn auto_moderation_rule_create(&self, ctx: Context, rule: Rule) {
-        send_event!(self, BAutoModerationRuleCreate { ctx, rule });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BAutoModerationRuleCreate { ctx, rule }
+        );
     }
 
     async fn auto_moderation_rule_update(&self, ctx: Context, rule: Rule) {
-        send_event!(self, BAutoModerationRuleUpdate { ctx, rule });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BAutoModerationRuleUpdate { ctx, rule }
+        );
     }
 
     async fn auto_moderation_rule_delete(&self, ctx: Context, rule: Rule) {
-        send_event!(self, BAutoModerationRuleDelete { ctx, rule });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BAutoModerationRuleDelete { ctx, rule }
+        );
     }
 
     async fn auto_moderation_action_execution(&self, ctx: Context, execution: ActionExecution) {
-        send_event!(self, BAutoModerationActionExecution { ctx, execution });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BAutoModerationActionExecution { ctx, execution }
+        );
     }
 
     #[cfg(feature = "bot_cache")]
     async fn cache_ready(&self, ctx: Context, guilds: Vec<GuildId>) {
-        send_event!(self, BCacheRead { ctx, guilds });
+        send_event!(self, EventCollectionBot, BCacheRead { ctx, guilds });
     }
 
     #[cfg(feature = "bot_cache")]
     async fn shards_ready(&self, ctx: Context, total_shards: u32) {
-        send_event!(self, BShardsReady { ctx, total_shards });
+        send_event!(self, EventCollectionBot, BShardsReady { ctx, total_shards });
     }
 
     async fn channel_create(&self, ctx: Context, channel: GuildChannel) {
-        send_event!(self, BChannelCreate { ctx, channel });
+        send_event!(self, EventCollectionBot, BChannelCreate { ctx, channel });
     }
 
     async fn category_create(&self, ctx: Context, category: GuildChannel) {
-        send_event!(self, BCategoryCreate { ctx, category });
+        send_event!(self, EventCollectionBot, BCategoryCreate { ctx, category });
     }
 
     async fn category_delete(&self, ctx: Context, category: GuildChannel) {
-        send_event!(self, BCategoryDelete { ctx, category });
+        send_event!(self, EventCollectionBot, BCategoryDelete { ctx, category });
     }
 
     async fn channel_delete(
@@ -64,6 +84,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BChannelDelete {
                 ctx,
                 channel,
@@ -73,11 +94,11 @@ impl EventHandler for Handle {
     }
 
     async fn channel_pins_update(&self, ctx: Context, pin: ChannelPinsUpdateEvent) {
-        send_event!(self, BChannelPinUpdate { ctx, pin });
+        send_event!(self, EventCollectionBot, BChannelPinUpdate { ctx, pin });
     }
 
     async fn channel_update(&self, ctx: Context, old: Option<GuildChannel>, new: GuildChannel) {
-        send_event!(self, BChannelUpdate { ctx, old, new });
+        send_event!(self, EventCollectionBot, BChannelUpdate { ctx, old, new });
     }
 
     async fn guild_audit_log_entry_create(
@@ -88,6 +109,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildAuditLogEntryCreate {
                 ctx,
                 entry,
@@ -99,6 +121,7 @@ impl EventHandler for Handle {
     async fn guild_ban_addition(&self, ctx: Context, guild_id: GuildId, banned_user: User) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildBanAddition {
                 ctx,
                 guild_id,
@@ -110,6 +133,7 @@ impl EventHandler for Handle {
     async fn guild_ban_removal(&self, ctx: Context, guild_id: GuildId, unbanned_user: User) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildBanRemoval {
                 ctx,
                 guild_id,
@@ -119,12 +143,17 @@ impl EventHandler for Handle {
     }
 
     async fn guild_create(&self, ctx: Context, guild: Guild, is_new: Option<bool>) {
-        send_event!(self, BGuildCreate { ctx, guild, is_new });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildCreate { ctx, guild, is_new }
+        );
     }
 
     async fn guild_delete(&self, ctx: Context, incomplete: UnavailableGuild, full: Option<Guild>) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildDelete {
                 ctx,
                 incomplete,
@@ -141,6 +170,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildEmojisUpdate {
                 ctx,
                 guild_id,
@@ -150,11 +180,19 @@ impl EventHandler for Handle {
     }
 
     async fn guild_integrations_update(&self, ctx: Context, guild_id: GuildId) {
-        send_event!(self, BGuildIntegrationsUpdate { ctx, guild_id });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildIntegrationsUpdate { ctx, guild_id }
+        );
     }
 
     async fn guild_member_addition(&self, ctx: Context, new_member: Member) {
-        send_event!(self, BGuildMemberAddition { ctx, new_member });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildMemberAddition { ctx, new_member }
+        );
     }
 
     async fn guild_member_removal(
@@ -166,6 +204,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildMemberRemoval {
                 ctx,
                 guild_id,
@@ -184,6 +223,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildMemberUpdate {
                 ctx,
                 old_if_available,
@@ -194,11 +234,11 @@ impl EventHandler for Handle {
     }
 
     async fn guild_members_chunk(&self, ctx: Context, chunk: GuildMembersChunkEvent) {
-        send_event!(self, BGuildMembersChunk { ctx, chunk });
+        send_event!(self, EventCollectionBot, BGuildMembersChunk { ctx, chunk });
     }
 
     async fn guild_role_create(&self, ctx: Context, new: Role) {
-        send_event!(self, BGuildRoleCreate { ctx, new });
+        send_event!(self, EventCollectionBot, BGuildRoleCreate { ctx, new });
     }
 
     async fn guild_role_delete(
@@ -210,6 +250,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildRoleDelete {
                 ctx,
                 guild_id,
@@ -227,6 +268,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildRoleUpdate {
                 ctx,
                 old_data_if_available,
@@ -243,6 +285,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildStickersUpdate {
                 ctx,
                 guild_id,
@@ -259,6 +302,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BGuildUpdate {
                 ctx,
                 old_data_if_available,
@@ -268,15 +312,15 @@ impl EventHandler for Handle {
     }
 
     async fn invite_create(&self, ctx: Context, data: InviteCreateEvent) {
-        send_event!(self, BInviteCreate { ctx, data });
+        send_event!(self, EventCollectionBot, BInviteCreate { ctx, data });
     }
 
     async fn invite_delete(&self, ctx: Context, data: InviteDeleteEvent) {
-        send_event!(self, BInviteDelete { ctx, data });
+        send_event!(self, EventCollectionBot, BInviteDelete { ctx, data });
     }
 
     async fn message(&self, ctx: Context, new_message: Message) {
-        send_event!(self, BMessage { ctx, new_message });
+        send_event!(self, EventCollectionBot, BMessage { ctx, new_message });
     }
 
     async fn message_delete(
@@ -288,6 +332,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BMessageDelete {
                 ctx,
                 channel_id,
@@ -306,6 +351,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BMessageDeleteBulk {
                 ctx,
                 channel_id,
@@ -324,6 +370,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BMessageUpdate {
                 ctx,
                 old_if_available,
@@ -334,12 +381,13 @@ impl EventHandler for Handle {
     }
 
     async fn reaction_add(&self, ctx: Context, add_reaction: Reaction) {
-        send_event!(self, BReactionAdd { ctx, add_reaction });
+        send_event!(self, EventCollectionBot, BReactionAdd { ctx, add_reaction });
     }
 
     async fn reaction_remove(&self, ctx: Context, removed_reaction: Reaction) {
         send_event!(
             self,
+            EventCollectionBot,
             BReactionRemove {
                 ctx,
                 removed_reaction
@@ -355,6 +403,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BReactionRemoveAll {
                 ctx,
                 channel_id,
@@ -366,6 +415,7 @@ impl EventHandler for Handle {
     async fn reaction_remove_emoji(&self, ctx: Context, removed_reactions: Reaction) {
         send_event!(
             self,
+            EventCollectionBot,
             BReactionRemoveEmoji {
                 ctx,
                 removed_reactions
@@ -374,12 +424,13 @@ impl EventHandler for Handle {
     }
 
     async fn presence_update(&self, ctx: Context, new_data: Presence) {
-        send_event!(self, BPresenceUpdate { ctx, new_data });
+        send_event!(self, EventCollectionBot, BPresenceUpdate { ctx, new_data });
     }
 
     async fn ready(&self, ctx: Context, data_about_bot: Ready) {
         send_event!(
             self,
+            EventCollectionBot,
             BReadyEvent {
                 ctx,
                 data_about_bot
@@ -388,27 +439,31 @@ impl EventHandler for Handle {
     }
 
     async fn resume(&self, ctx: Context, event: ResumedEvent) {
-        send_event!(self, BResume { ctx, event });
+        send_event!(self, EventCollectionBot, BResume { ctx, event });
     }
 
     async fn shard_stage_update(&self, ctx: Context, event: ShardStageUpdateEvent) {
-        send_event!(self, BShardStageUpdate { ctx, event });
+        send_event!(self, EventCollectionBot, BShardStageUpdate { ctx, event });
     }
 
     async fn typing_start(&self, ctx: Context, event: TypingStartEvent) {
-        send_event!(self, BTypingStart { ctx, event });
+        send_event!(self, EventCollectionBot, BTypingStart { ctx, event });
     }
 
     async fn user_update(&self, ctx: Context, old_data: Option<CurrentUser>, new: CurrentUser) {
-        send_event!(self, BUserUpdate { ctx, old_data, new });
+        send_event!(self, EventCollectionBot, BUserUpdate { ctx, old_data, new });
     }
 
     async fn voice_server_update(&self, ctx: Context, event: VoiceServerUpdateEvent) {
-        send_event!(self, BVoiceServerUpdate { ctx, event });
+        send_event!(self, EventCollectionBot, BVoiceServerUpdate { ctx, event });
     }
 
     async fn voice_state_update(&self, ctx: Context, old: Option<VoiceState>, new: VoiceState) {
-        send_event!(self, BVoiceStateUpdate { ctx, old, new });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BVoiceStateUpdate { ctx, old, new }
+        );
     }
 
     async fn voice_channel_status_update(
@@ -421,6 +476,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BVoiceChannelStatusUpdate {
                 ctx,
                 old,
@@ -439,6 +495,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BWebhookUpdate {
                 ctx,
                 guild_id,
@@ -448,20 +505,33 @@ impl EventHandler for Handle {
     }
 
     async fn interaction_create(&self, ctx: Context, interaction: Interaction) {
-        send_event!(self, BInteractionCreate { ctx, interaction });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BInteractionCreate { ctx, interaction }
+        );
     }
 
     async fn integration_create(&self, ctx: Context, integration: Integration) {
-        send_event!(self, BIntegrationCreate { ctx, integration });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BIntegrationCreate { ctx, integration }
+        );
     }
 
     async fn integration_update(&self, ctx: Context, integration: Integration) {
-        send_event!(self, BIntegrationUpdate { ctx, integration });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BIntegrationUpdate { ctx, integration }
+        );
     }
 
     async fn stage_instance_create(&self, ctx: Context, stage_instance: StageInstance) {
         send_event!(
             self,
+            EventCollectionBot,
             BStageInstanceCreate {
                 ctx,
                 stage_instance
@@ -472,6 +542,7 @@ impl EventHandler for Handle {
     async fn stage_instance_update(&self, ctx: Context, stage_instance: StageInstance) {
         send_event!(
             self,
+            EventCollectionBot,
             BStageInstanceUpdate {
                 ctx,
                 stage_instance
@@ -482,6 +553,7 @@ impl EventHandler for Handle {
     async fn stage_instance_delete(&self, ctx: Context, stage_instance: StageInstance) {
         send_event!(
             self,
+            EventCollectionBot,
             BStageInstanceDelete {
                 ctx,
                 stage_instance
@@ -490,11 +562,11 @@ impl EventHandler for Handle {
     }
 
     async fn thread_create(&self, ctx: Context, thread: GuildChannel) {
-        send_event!(self, BThreadCreate { ctx, thread });
+        send_event!(self, EventCollectionBot, BThreadCreate { ctx, thread });
     }
 
     async fn thread_update(&self, ctx: Context, old: Option<GuildChannel>, new: GuildChannel) {
-        send_event!(self, BThreadUpdate { ctx, old, new });
+        send_event!(self, EventCollectionBot, BThreadUpdate { ctx, old, new });
     }
 
     async fn thread_delete(
@@ -505,6 +577,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BThreadDelete {
                 ctx,
                 thread,
@@ -516,6 +589,7 @@ impl EventHandler for Handle {
     async fn thread_list_sync(&self, ctx: Context, thread_list_sync: ThreadListSyncEvent) {
         send_event!(
             self,
+            EventCollectionBot,
             BThreadListSync {
                 ctx,
                 thread_list_sync
@@ -524,7 +598,11 @@ impl EventHandler for Handle {
     }
 
     async fn thread_member_update(&self, ctx: Context, thread_member: ThreadMember) {
-        send_event!(self, BThreadMemberUpdate { ctx, thread_member });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BThreadMemberUpdate { ctx, thread_member }
+        );
     }
 
     async fn thread_members_update(
@@ -534,6 +612,7 @@ impl EventHandler for Handle {
     ) {
         send_event!(
             self,
+            EventCollectionBot,
             BThreadMembersUpdate {
                 ctx,
                 thread_members_update
@@ -542,15 +621,27 @@ impl EventHandler for Handle {
     }
 
     async fn guild_scheduled_event_create(&self, ctx: Context, event: ScheduledEvent) {
-        send_event!(self, BGuildScheduledEventCreate { ctx, event });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildScheduledEventCreate { ctx, event }
+        );
     }
 
     async fn guild_scheduled_event_update(&self, ctx: Context, event: ScheduledEvent) {
-        send_event!(self, BGuildScheduledEventUpdate { ctx, event });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildScheduledEventUpdate { ctx, event }
+        );
     }
 
     async fn guild_scheduled_event_delete(&self, ctx: Context, event: ScheduledEvent) {
-        send_event!(self, BGuildScheduledEventDelete { ctx, event });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildScheduledEventDelete { ctx, event }
+        );
     }
 
     async fn guild_scheduled_event_user_add(
@@ -558,7 +649,11 @@ impl EventHandler for Handle {
         ctx: Context,
         subscribed: GuildScheduledEventUserAddEvent,
     ) {
-        send_event!(self, BGuildScheduledEventUserAdd { ctx, subscribed });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildScheduledEventUserAdd { ctx, subscribed }
+        );
     }
 
     async fn guild_scheduled_event_user_remove(
@@ -566,30 +661,46 @@ impl EventHandler for Handle {
         ctx: Context,
         unsubscribed: GuildScheduledEventUserRemoveEvent,
     ) {
-        send_event!(self, BGuildScheduledEventUserRemove { ctx, unsubscribed });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BGuildScheduledEventUserRemove { ctx, unsubscribed }
+        );
     }
 
     async fn entitlement_create(&self, ctx: Context, entitlement: Entitlement) {
-        send_event!(self, BEntitlementCreate { ctx, entitlement });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BEntitlementCreate { ctx, entitlement }
+        );
     }
 
     async fn entitlement_update(&self, ctx: Context, entitlement: Entitlement) {
-        send_event!(self, BEntitlementUpdate { ctx, entitlement });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BEntitlementUpdate { ctx, entitlement }
+        );
     }
 
     async fn entitlement_delete(&self, ctx: Context, entitlement: Entitlement) {
-        send_event!(self, BEntitlementDelete { ctx, entitlement });
+        send_event!(
+            self,
+            EventCollectionBot,
+            BEntitlementDelete { ctx, entitlement }
+        );
     }
 
     async fn poll_vote_add(&self, ctx: Context, event: MessagePollVoteAddEvent) {
-        send_event!(self, BPollVoteAdd { ctx, event });
+        send_event!(self, EventCollectionBot, BPollVoteAdd { ctx, event });
     }
 
     async fn poll_vote_remove(&self, ctx: Context, event: MessagePollVoteRemoveEvent) {
-        send_event!(self, BPollVoteRemove { ctx, event });
+        send_event!(self, EventCollectionBot, BPollVoteRemove { ctx, event });
     }
 
     async fn ratelimit(&self, data: RatelimitInfo) {
-        send_event!(self, BRateLimit { data });
+        send_event!(self, EventCollectionBot, BRateLimit { data });
     }
 }

--- a/src/channel.rs
+++ b/src/channel.rs
@@ -1,36 +1,11 @@
 //! Internal Channel Plugin, that just add
 //! channel resource
 
-use crate::{
-    events::{send_events, EventCollection},
-    DiscordSet,
-};
-use bevy_app::{App, Plugin, Update};
-use bevy_ecs::{prelude::Resource, schedule::IntoSystemConfigs};
+use bevy_ecs::prelude::Resource;
 use flume::{Receiver, Sender};
 
-pub struct ChannelPlugin;
-
 #[derive(Resource)]
-pub struct ChannelRes {
-    pub rx: Receiver<EventCollection>,
-    pub tx: Sender<EventCollection>,
-}
-
-impl Plugin for ChannelPlugin {
-    fn build(&self, app: &mut App) {
-        let (tx, rx) = flume::unbounded();
-
-        app.insert_resource(ChannelRes { tx, rx });
-    }
-}
-
-#[cfg(any(feature = "bot", feature = "rich_presence"))]
-pub struct ChannelListener;
-
-#[cfg(any(feature = "bot", feature = "rich_presence"))]
-impl Plugin for ChannelListener {
-    fn build(&self, app: &mut App) {
-        app.add_systems(Update, send_events.in_set(DiscordSet));
-    }
+pub struct ChannelRes<T> {
+    pub rx: Receiver<T>,
+    pub tx: Sender<T>,
 }

--- a/src/common.rs
+++ b/src/common.rs
@@ -34,6 +34,7 @@ macro_rules! initialize_field_with_doc {
 macro_rules! create_event_collection_and_handler {
     (
         $name:ident,
+        $fn_name:ident,
         $(
             $(#[$meta:meta])? $variant:ident
         ),* $(,)?
@@ -57,8 +58,8 @@ macro_rules! create_event_collection_and_handler {
             }
 
             // Define the function to handle the events and send them through EventWriter
-            pub(crate) fn send_events(
-                channel: bevy_ecs::prelude::Res<$crate::channel::ChannelRes>,
+            pub(crate) fn [<send_events_ $fn_name>](
+                channel: bevy_ecs::prelude::Res<$crate::channel::ChannelRes<$name>>,
                 mut events_system_param: [< $name SystemParam >]
             ) {
                 if let Ok(event) = channel.rx.try_recv() {
@@ -77,9 +78,9 @@ macro_rules! create_event_collection_and_handler {
 }
 
 macro_rules! send_event {
-    ($self:ident, $event:ident { $($field:ident),* }) => {
+    ($self:ident, $collection: ident, $event:ident { $($field:ident),* }) => {
         if let Err(_) = $self.tx.send_async(
-            $crate::events::EventCollection::$event($event {
+            $crate::events::$collection::$event($event {
                 $($field),*
             })
         ).await {
@@ -89,9 +90,9 @@ macro_rules! send_event {
 }
 
 macro_rules! send_event_tuple {
-    ($self:ident, $event:ident ( $($field:ident),* )) => {
+    ($self:ident, $collection: ident, $event:ident ( $($field:ident),* )) => {
         if let Err(_) = $self.tx.send_async(
-            $crate::events::EventCollection::$event($event ( $($field),* ))
+            $crate::events::$collection::$event($event ( $($field),* ))
         ).await {
             error!("Unable to send event to the channel")
         }

--- a/src/events.rs
+++ b/src/events.rs
@@ -824,173 +824,98 @@ use bot::*;
 #[cfg(feature = "rich_presence")]
 use rich_presence::*;
 
+#[cfg(feature = "bot")]
 create_event_collection_and_handler!(
-    EventCollection,
-    #[cfg(feature = "bot")]
+    EventCollectionBot,
+    bot,
     BCommandPermissionsUpdate,
-    #[cfg(feature = "bot")]
     BAutoModerationRuleCreate,
-    #[cfg(feature = "bot")]
     BAutoModerationRuleUpdate,
-    #[cfg(feature = "bot")]
     BAutoModerationRuleDelete,
-    #[cfg(feature = "bot")]
     BAutoModerationActionExecution,
     #[cfg(all(feature = "bot_cache", feature = "bot_cache"))]
     BCacheRead,
     #[cfg(all(feature = "bot_cache", feature = "bot_cache"))]
     BShardsReady,
-    #[cfg(feature = "bot")]
     BChannelCreate,
-    #[cfg(feature = "bot")]
     BCategoryCreate,
-    #[cfg(feature = "bot")]
     BCategoryDelete,
-    #[cfg(feature = "bot")]
     BChannelDelete,
-    #[cfg(feature = "bot")]
     BChannelPinUpdate,
-    #[cfg(feature = "bot")]
     BChannelUpdate,
-    #[cfg(feature = "bot")]
     BGuildAuditLogEntryCreate,
-    #[cfg(feature = "bot")]
     BGuildBanAddition,
-    #[cfg(feature = "bot")]
     BGuildBanRemoval,
-    #[cfg(feature = "bot")]
     BGuildCreate,
-    #[cfg(feature = "bot")]
     BGuildDelete,
-    #[cfg(feature = "bot")]
     BGuildEmojisUpdate,
-    #[cfg(feature = "bot")]
     BGuildIntegrationsUpdate,
-    #[cfg(feature = "bot")]
     BGuildMemberAddition,
-    #[cfg(feature = "bot")]
     BGuildMemberRemoval,
-    #[cfg(feature = "bot")]
     BGuildMemberUpdate,
-    #[cfg(feature = "bot")]
     BGuildMembersChunk,
-    #[cfg(feature = "bot")]
     BGuildRoleCreate,
-    #[cfg(feature = "bot")]
     BGuildRoleDelete,
-    #[cfg(feature = "bot")]
     BGuildRoleUpdate,
-    #[cfg(feature = "bot")]
     BGuildStickersUpdate,
-    #[cfg(feature = "bot")]
     BGuildUpdate,
-    #[cfg(feature = "bot")]
     BInviteCreate,
-    #[cfg(feature = "bot")]
     BInviteDelete,
-    #[cfg(feature = "bot")]
     BMessage,
-    #[cfg(feature = "bot")]
     BMessageDelete,
-    #[cfg(feature = "bot")]
     BMessageDeleteBulk,
-    #[cfg(feature = "bot")]
     BMessageUpdate,
-    #[cfg(feature = "bot")]
     BReactionAdd,
-    #[cfg(feature = "bot")]
     BReactionRemove,
-    #[cfg(feature = "bot")]
     BReactionRemoveAll,
-    #[cfg(feature = "bot")]
     BReactionRemoveEmoji,
-    #[cfg(feature = "bot")]
     BPresenceUpdate,
-    #[cfg(feature = "bot")]
     BReadyEvent,
-    #[cfg(feature = "bot")]
     BResume,
-    #[cfg(feature = "bot")]
     BShardStageUpdate,
-    #[cfg(feature = "bot")]
     BTypingStart,
-    #[cfg(feature = "bot")]
     BUserUpdate,
-    #[cfg(feature = "bot")]
     BVoiceServerUpdate,
-    #[cfg(feature = "bot")]
     BVoiceStateUpdate,
-    #[cfg(feature = "bot")]
     BVoiceChannelStatusUpdate,
-    #[cfg(feature = "bot")]
     BWebhookUpdate,
-    #[cfg(feature = "bot")]
     BInteractionCreate,
-    #[cfg(feature = "bot")]
     BIntegrationCreate,
-    #[cfg(feature = "bot")]
     BIntegrationUpdate,
-    #[cfg(feature = "bot")]
     BStageInstanceCreate,
-    #[cfg(feature = "bot")]
     BStageInstanceUpdate,
-    #[cfg(feature = "bot")]
     BStageInstanceDelete,
-    #[cfg(feature = "bot")]
     BThreadCreate,
-    #[cfg(feature = "bot")]
     BThreadUpdate,
-    #[cfg(feature = "bot")]
     BThreadDelete,
-    #[cfg(feature = "bot")]
     BThreadListSync,
-    #[cfg(feature = "bot")]
     BThreadMemberUpdate,
-    #[cfg(feature = "bot")]
     BThreadMembersUpdate,
-    #[cfg(feature = "bot")]
     BGuildScheduledEventCreate,
-    #[cfg(feature = "bot")]
     BGuildScheduledEventUpdate,
-    #[cfg(feature = "bot")]
     BGuildScheduledEventDelete,
-    #[cfg(feature = "bot")]
     BGuildScheduledEventUserAdd,
-    #[cfg(feature = "bot")]
     BGuildScheduledEventUserRemove,
-    #[cfg(feature = "bot")]
     BEntitlementCreate,
-    #[cfg(feature = "bot")]
     BEntitlementUpdate,
-    #[cfg(feature = "bot")]
     BEntitlementDelete,
-    #[cfg(feature = "bot")]
     BPollVoteAdd,
-    #[cfg(feature = "bot")]
     BPollVoteRemove,
-    #[cfg(feature = "bot")]
     BRateLimit,
-    // -------------
-    // Rich Presence
-    // -------------
-    #[cfg(feature = "rich_presence")]
+);
+
+#[cfg(feature = "rich_presence")]
+create_event_collection_and_handler!(
+    EventCollectionRichPresence,
+    rich_presence,
     RichPresenceError,
-    #[cfg(feature = "rich_presence")]
     RichPresenceReady,
-    #[cfg(feature = "rich_presence")]
     RichPresenceDisconnected,
-    #[cfg(feature = "rich_presence")]
     RichPresenceCurrentUserUpdate,
-    #[cfg(feature = "rich_presence")]
     RichPresenceActivityJoin,
-    #[cfg(feature = "rich_presence")]
     RichPresenceActivitySpectate,
-    #[cfg(feature = "rich_presence")]
     RichPresenceActivityJoinRequest,
-    #[cfg(feature = "rich_presence")]
     RichPresenceActivityInvite,
-    #[cfg(feature = "rich_presence")]
     RichPresenceOverlayUpdate,
-    #[cfg(feature = "rich_presence")]
     RichPresenceRelationshipUpdate
 );

--- a/src/rich_presence/event_handlers.rs
+++ b/src/rich_presence/event_handlers.rs
@@ -1,5 +1,5 @@
 use crate::common::{send_event, send_event_tuple};
-use crate::events::{rich_presence::*, EventCollection};
+use crate::events::{rich_presence::*, EventCollectionRichPresence};
 use async_trait::async_trait;
 use discord_sdk::activity::events::{InviteEvent, JoinRequestEvent, SecretEvent};
 use discord_sdk::overlay::events::UpdateEvent as OverlayUpdateEvent;
@@ -9,7 +9,7 @@ use flume::Sender;
 use tracing::error;
 
 pub struct EventHandler {
-    pub tx: Sender<EventCollection>,
+    pub tx: Sender<EventCollectionRichPresence>,
 }
 
 #[async_trait]
@@ -18,16 +18,16 @@ impl DiscordHandler for EventHandler {
         match msg {
             DiscordMsg::Error(err) => error!("Got an error from `discord-sdk` i.e. feature `rich-presence` in `bevy-discord`. Error => {:?}", err),
             DiscordMsg::Event(event) => match event {
-                Event::Ready(ConnectEvent {version, user, ..}) => send_event!(self, RichPresenceReady { version, user }),
-                Event::Disconnected { reason } => send_event!(self, RichPresenceDisconnected { reason }),
-                Event::CurrentUserUpdate(UpdateEvent { user }) => send_event!(self, RichPresenceCurrentUserUpdate { user }),
-                Event::ActivityJoin(SecretEvent { secret }) => send_event!(self, RichPresenceActivityJoin { secret }),
-                Event::ActivitySpectate(SecretEvent { secret }) => send_event!(self, RichPresenceActivitySpectate { secret }),
-                Event::ActivityJoinRequest(JoinRequestEvent { user }) => send_event!(self, RichPresenceActivityJoinRequest { user }),
-                Event::ActivityInvite(InviteEvent (activity_invite)) => send_event_tuple!(self, RichPresenceActivityInvite(activity_invite)),
-                Event::OverlayUpdate(OverlayUpdateEvent { enabled, visible }) => send_event!(self, RichPresenceOverlayUpdate { enabled, visible }),
-                Event::RelationshipUpdate(relationship) => send_event_tuple!(self, RichPresenceRelationshipUpdate(relationship)),
-                _ => send_event_tuple!(self, RichPresenceError(event))
+                Event::Ready(ConnectEvent {version, user, ..}) => send_event!(self, EventCollectionRichPresence, RichPresenceReady { version, user }),
+                Event::Disconnected { reason } => send_event!(self, EventCollectionRichPresence, RichPresenceDisconnected { reason }),
+                Event::CurrentUserUpdate(UpdateEvent { user }) => send_event!(self, EventCollectionRichPresence, RichPresenceCurrentUserUpdate { user }),
+                Event::ActivityJoin(SecretEvent { secret }) => send_event!(self, EventCollectionRichPresence, RichPresenceActivityJoin { secret }),
+                Event::ActivitySpectate(SecretEvent { secret }) => send_event!(self, EventCollectionRichPresence, RichPresenceActivitySpectate { secret }),
+                Event::ActivityJoinRequest(JoinRequestEvent { user }) => send_event!(self, EventCollectionRichPresence, RichPresenceActivityJoinRequest { user }),
+                Event::ActivityInvite(InviteEvent (activity_invite)) => send_event_tuple!(self, EventCollectionRichPresence, RichPresenceActivityInvite(activity_invite)),
+                Event::OverlayUpdate(OverlayUpdateEvent { enabled, visible }) => send_event!(self, EventCollectionRichPresence, RichPresenceOverlayUpdate { enabled, visible }),
+                Event::RelationshipUpdate(relationship) => send_event_tuple!(self, EventCollectionRichPresence, RichPresenceRelationshipUpdate(relationship)),
+                _ => send_event_tuple!(self, EventCollectionRichPresence, RichPresenceError(event))
             }
         }
     }

--- a/src/rich_presence/mod.rs
+++ b/src/rich_presence/mod.rs
@@ -9,11 +9,11 @@
 
 mod event_handlers;
 
-use crate::events::rich_presence::*;
+use crate::events::{rich_presence::*, send_events_rich_presence, EventCollectionRichPresence};
 use crate::rich_presence::event_handlers::EventHandler;
 use crate::DiscordSet;
 use crate::{channel::ChannelRes, runtime::tokio_runtime};
-use bevy_app::{App, Plugin, Startup};
+use bevy_app::{App, Plugin, Startup, Update};
 use bevy_ecs::prelude::*;
 use discord_sdk::Discord;
 use std::sync::Arc;
@@ -29,20 +29,9 @@ impl DiscordRichPresencePlugin {
 
 impl Plugin for DiscordRichPresencePlugin {
     fn build(&self, app: &mut App) {
-        // Check if internal plugins are added
-        // If you are adding new internal plugins, make sure to also update DiscordBotPlugin
-        if app
-            .get_added_plugins::<super::channel::ChannelPlugin>()
-            .is_empty()
-        {
-            app.add_plugins(super::channel::ChannelPlugin);
-        }
-        if app
-            .get_added_plugins::<super::channel::ChannelListener>()
-            .is_empty()
-        {
-            app.add_plugins(super::channel::ChannelListener);
-        }
+        let (tx, rx) = flume::unbounded::<EventCollectionRichPresence>();
+        let channel_res = ChannelRes { tx, rx };
+        app.insert_resource(channel_res);
 
         app.insert_resource(self.0.clone())
             .add_event::<RichPresenceError>()
@@ -55,19 +44,15 @@ impl Plugin for DiscordRichPresencePlugin {
             .add_event::<RichPresenceActivityInvite>()
             .add_event::<RichPresenceOverlayUpdate>()
             .add_event::<RichPresenceRelationshipUpdate>()
-            .add_systems(
-                Startup,
-                setup_rich_presence
-                    .in_set(DiscordSet)
-                    .run_if(resource_exists::<ChannelRes>),
-            );
+            .add_systems(Startup, setup_rich_presence)
+            .add_systems(Update, send_events_rich_presence.in_set(DiscordSet));
     }
 }
 
 fn setup_rich_presence(
     mut commands: Commands,
     discord_rich_presence_config: Res<crate::config::DiscordRichPresenceConfig>,
-    channel_res: Res<ChannelRes>,
+    channel_res: Res<ChannelRes<EventCollectionRichPresence>>,
 ) {
     let tx = channel_res.tx.clone();
     let event_handler = Box::new(EventHandler { tx });


### PR DESCRIPTION
Trying to make `send_events` system better in performance by not using world directly in the system

## TODOs

- [x] Break `send_events` system into two parts, one for `bot` and `rich_presence` modules.
      _This would make the `send_events` system work on `full` feature without adding both the modules and registering their events_
- [ ] ~Add benchmarks to verify it is improving performance~